### PR TITLE
Fixed jpa-version and data.sql encoding

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>1.5.10.RELEASE</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>${parent.version}</version>
+            <version>1.5.10.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 flyway.enabled = true
+spring.datasource.sqlScriptEncoding=UTF-8


### PR DESCRIPTION
w przypadku `<version>${parent.version}</version>` pojawiały się błędy - [Warnings](http://files.tinypic.pl/i/00961/10b60w9v9p9i.png)
W przypadku polskich znaków w kategoriach (przy zapytaniach sql) kodowanie było niepoprawne.