### PR TITLE
reverse_sort_order

### DIFF
--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -32,7 +32,7 @@ public class OfferService {
 
     public List<Offer> getAll(Specification<Offer> filter) {
         return repository.findAll(filter).stream()
-                .sorted(Comparator.comparing(Offer::getDate))
+                .sorted(Comparator.comparing(Offer::getDate).reversed())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Zmiana kolejności sortowania wyników wyszukiwania z "prostej w/g kolejności dodania" (pierwsze dodane -> pierwsze na liście wyszukiwania), na "odwrotną w/g kolejności dodania" (pierwsze dodane -> ostatnie na liście wyszukiwania) na podstawie doprecyzowania wymagań przez PO.