### PR TITLE
PRODPFIP-139 - user registration form

### DIFF
--- a/backend/src/main/java/com/intive/shopme/UserRegistration/Address.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/Address.java
@@ -1,0 +1,36 @@
+package com.intive.shopme.UserRegistration;
+
+import com.intive.shopme.base.Identifiable;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+
+@Entity
+@ApiModel(value = "Adress data", description = "Represents data for adress")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Address extends Identifiable {
+
+    @ApiModelProperty(value = "Represents street name",
+            required = true, position = 2, example = "Niepodległości")
+    private String street;
+
+    @ApiModelProperty(value = "Represents home number",
+            required = true, position = 3, example = "12/1")
+    private String number;
+
+    @ApiModelProperty(value = "Represents city",
+            required = true, position = 4, example = "Szczecin")
+    private String city;
+
+    @ApiModelProperty(value = "Represents ZIP code",
+            required = true, position = 5, example = "70-125")
+    private String zipCode;
+}

--- a/backend/src/main/java/com/intive/shopme/UserRegistration/Invoice.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/Invoice.java
@@ -1,0 +1,37 @@
+package com.intive.shopme.UserRegistration;
+
+import com.intive.shopme.base.Identifiable;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToOne;
+
+@Entity
+@ApiModel(value = "Invoice data", description = "Represents data for invoice")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+class Invoice extends Identifiable {
+
+    @ApiModelProperty(value = "Represents user's company name",
+            required = true, position = 2, example = "Januszex Sp.z.o.")
+    private String companyName;
+
+    @ApiModelProperty(value = "Represents user's company NIP number",
+            required = true, position = 3, example = "123-456-78-90")
+    private String nip;
+
+    @ApiModelProperty(value = "Represents user's company address",
+            required = true, position = 4)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    private Address invoiceAddress;
+
+}

--- a/backend/src/main/java/com/intive/shopme/UserRegistration/User.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/User.java
@@ -1,0 +1,61 @@
+package com.intive.shopme.UserRegistration;
+
+import com.intive.shopme.base.Identifiable;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToOne;
+
+@Entity
+@ApiModel(value = "users", description = "Represents the user")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class User extends Identifiable {
+
+    @ApiModelProperty(value = "Represents user's name",
+            required = true, position = 2, example = "Jan")
+    private String name;
+
+    @ApiModelProperty(value = "Represents user's surname",
+            required = true, position = 3, example = "Kowalski")
+    private String surname;
+
+    @ApiModelProperty(value = "Represents user's email",
+            required = true, position = 4, example = "unknown@gmail.com")
+    private String email;
+
+    @ApiModelProperty(value = "Represents user's password",
+            required = true, position = 5, example = "password")
+    private String password;
+
+    @ApiModelProperty(value = "Represents user's phone number",
+            required = true, position = 6, example = "0234567890")
+    private String phoneNumber;
+
+    @ApiModelProperty(value = "Represents user's bank account number",
+            required = true, position = 7, example = "01234567890123456789012345")
+    private String bankAccount;
+
+    @ApiModelProperty(value = "Represents user's address",
+            required = true, position = 8)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    private Address address;
+
+    @ApiModelProperty(value = "Represents request user`s for invoice",
+            required = true, position = 9, example = "YES")
+    private Boolean invoiceRequest;
+
+    @ApiModelProperty(value = "Represents invoice data for user`s", position = 10)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    private Invoice invoice;
+
+}

--- a/backend/src/main/java/com/intive/shopme/UserRegistration/UserController.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/UserController.java
@@ -1,0 +1,33 @@
+package com.intive.shopme.UserRegistration;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import static com.intive.shopme.config.ApiUrl.USERS;
+
+@RestController
+@RequestMapping(value = USERS)
+@Api(value = "users", description = "REST API for users operation", tags = "Users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    @ApiOperation("Saves new users")
+    public void add(@RequestBody User user) {
+        user.setId(UUID.randomUUID());
+        userService.add(user);
+    }
+}

--- a/backend/src/main/java/com/intive/shopme/UserRegistration/UserRepository.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/UserRepository.java
@@ -1,0 +1,9 @@
+package com.intive.shopme.UserRegistration;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {
+}

--- a/backend/src/main/java/com/intive/shopme/UserRegistration/UserService.java
+++ b/backend/src/main/java/com/intive/shopme/UserRegistration/UserService.java
@@ -1,0 +1,23 @@
+package com.intive.shopme.UserRegistration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void add(User user) {
+        userRepository.save(user);
+    }
+}

--- a/backend/src/main/java/com/intive/shopme/config/ApiUrl.java
+++ b/backend/src/main/java/com/intive/shopme/config/ApiUrl.java
@@ -1,11 +1,10 @@
 package com.intive.shopme.config;
 
 public final class ApiUrl {
-
-    public static final String OFFERS_PATH = "/offers";
-    public static final String CATEGORIES_PATH = "/categories";
+    public static final String OFFERS = "/offers";
+    public static final String CATEGORIES = "/categories";
+    public static final String USERS = "/users";
 
     private ApiUrl() {
     }
-
 }

--- a/backend/src/main/java/com/intive/shopme/controller/CategoryController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/CategoryController.java
@@ -13,10 +13,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
-import static com.intive.shopme.config.ApiUrl.CATEGORIES_PATH;
+import static com.intive.shopme.config.ApiUrl.CATEGORIES;
 
 @RestController
-@RequestMapping(value = CATEGORIES_PATH)
+@RequestMapping(value = CATEGORIES)
 @Api(value = "category", description = "REST API for categories operations", tags = "Categories")
 public class CategoryController {
 

--- a/backend/src/main/java/com/intive/shopme/controller/OfferController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/OfferController.java
@@ -32,7 +32,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.intive.shopme.config.ApiUrl.OFFERS_PATH;
+import static com.intive.shopme.config.ApiUrl.OFFERS;
 import static com.intive.shopme.config.AppConfig.ACCEPTABLE_TITLE_SEARCH_CHARS;
 import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE;
 import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE_SIZE;
@@ -44,7 +44,7 @@ import static com.intive.shopme.config.AppConfig.PAGE_SIZE_MAX;
 
 @Validated
 @RestController
-@RequestMapping(value = OFFERS_PATH)
+@RequestMapping(value = OFFERS)
 @Api(value = "offer", description = "REST API for offers", tags = "Offers")
 public class OfferController {
 


### PR DESCRIPTION
Formularz do rejestracji nowego użytkownika - bez walidacji
całość stworzona w pakiecie UserRegistration więc przy przejściu na package by feature nie powinno być konfliktów
Paczka nie nazywa się User żeby nie mylić z istniejącą już klasą do dodawania oferty - pytałem analizy i potwierdzili, że obecna wersja formularza dodawania oferty musi pozostać do momentu całkowitego ukończenia UC5 czyli w pełni funkcjonalnej rejestracji
Formularz danych do faktury jest opcjonalny ale jego pola są wymagane przy dodawaniu usera w swaggerze można:
- usunąć formularz invoice, wtedy przy GET będziemy mieli invoice = null
- usunąć niektóre pola formularza invoice, wtedy pzy GET, będą widoczne wszystkie pola formularza (usunięte będą z wartością null)

Założyłem taska na stworzenie warunkowej walidacji, która będzie nadawała status required formularza danych do faktury w zależności od wartości (enum z wartościami "YES" i "NO") zmiennej określającej checkbox "Dane do faktury"