### PR TITLE
Paging support for offers search REST API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>9</java.version>
         <junit.jupiter.version>5.1.0</junit.jupiter.version>
         <junit.vintage.version>5.1.0</junit.vintage.version>
         <junit.platform.version>1.1.0</junit.platform.version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,6 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>9</java.version>
         <junit.jupiter.version>5.1.0</junit.jupiter.version>
         <junit.vintage.version>5.1.0</junit.vintage.version>
         <junit.platform.version>1.1.0</junit.platform.version>

--- a/backend/src/main/java/com/intive/shopme/ShopMeApplication.java
+++ b/backend/src/main/java/com/intive/shopme/ShopMeApplication.java
@@ -9,4 +9,5 @@ public class ShopMeApplication {
     public static void main(String[] args) {
         SpringApplication.run(ShopMeApplication.class, args);
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/config/ApiUrl.java
+++ b/backend/src/main/java/com/intive/shopme/config/ApiUrl.java
@@ -1,9 +1,11 @@
 package com.intive.shopme.config;
 
 public final class ApiUrl {
+
     public static final String OFFERS_PATH = "/offers";
     public static final String CATEGORIES_PATH = "/categories";
 
     private ApiUrl() {
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/config/AppConfig.java
+++ b/backend/src/main/java/com/intive/shopme/config/AppConfig.java
@@ -1,6 +1,9 @@
 package com.intive.shopme.config;
 
 public final class AppConfig {
+
+    public static final String ACCEPTABLE_TITLE_SEARCH_CHARS = "a-zA-Z0-9ąĄćĆęĘłŁńŃóÓśŚżŻźŹ ";
+
     public static final int USER_NAME_MIN_LENGTH = 3;
     public static final int USER_NAME_MAX_LENGTH = 20;
 
@@ -8,6 +11,15 @@ public final class AppConfig {
     public static final int OFFER_DESCRIPTION_MAX_LENGTH = 500;
     public static final int USER_DESCRIPTION_MAX_LENGTH = 800;
 
+    public static final int FIRST_PAGE = 1;
+    public static final String DEFAULT_PAGE = "1";
+    public static final String DEFAULT_PAGE_SIZE = "10";
+    public static final int PAGE_SIZE_MAX = 100;
+
+    public static final String DEFAULT_SORT_FIELD = "date";
+    public static final String DEFAULT_SORT_DIRECTION = "DESC";
+
     private AppConfig() {
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/config/SwaggerApiInfoConfigurer.java
+++ b/backend/src/main/java/com/intive/shopme/config/SwaggerApiInfoConfigurer.java
@@ -7,7 +7,7 @@ final class SwaggerApiInfoConfigurer {
 
     private static final String TITLE = "ShopMe by Intive Patronage `18 team";
     private static final String DESC = "ShopMe is a Web Application created during Intive Patronage `18 Project";
-    private static final String VERSION = "1.1";
+    private static final String VERSION = "1.2";
 
     private SwaggerApiInfoConfigurer() {
     }
@@ -15,4 +15,5 @@ final class SwaggerApiInfoConfigurer {
     static ApiInfo createApiInfo() {
         return new ApiInfoBuilder().title(TITLE).description(DESC).version(VERSION).build();
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/intive/shopme/config/SwaggerConfig.java
@@ -71,4 +71,5 @@ public class SwaggerConfig {
             }
         };
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/controller/OfferController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/OfferController.java
@@ -10,7 +10,12 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,14 +25,22 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
 import static com.intive.shopme.config.ApiUrl.OFFERS_PATH;
+import static com.intive.shopme.config.AppConfig.ACCEPTABLE_TITLE_SEARCH_CHARS;
+import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE;
+import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE_SIZE;
+import static com.intive.shopme.config.AppConfig.DEFAULT_SORT_DIRECTION;
+import static com.intive.shopme.config.AppConfig.DEFAULT_SORT_FIELD;
+import static com.intive.shopme.config.AppConfig.FIRST_PAGE;
 import static com.intive.shopme.config.AppConfig.OFFER_TITLE_MAX_LENGTH;
+import static com.intive.shopme.config.AppConfig.PAGE_SIZE_MAX;
 
 @Validated
 @RestController
@@ -50,11 +63,26 @@ public class OfferController {
     @PostMapping
     public void add(@RequestBody Offer offer) {
         offer.setId(UUID.randomUUID());
+        offer.setDate(Instant.now().toEpochMilli());
         service.add(offer);
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "title", value = "filter query for offers titles (optional)",
+            @ApiImplicitParam(name = "page", value = "requested page number (optional, counting from " + FIRST_PAGE +
+                    ", default = " + DEFAULT_PAGE + ")",
+                    defaultValue = DEFAULT_PAGE, dataType = "Long", paramType = "query"),
+            @ApiImplicitParam(name = "pageSize", value = "number of offers per page (optional, default = " +
+                    DEFAULT_PAGE_SIZE + ", max " + PAGE_SIZE_MAX + ")", allowableValues = "range[1, 5]",
+                    defaultValue = DEFAULT_PAGE_SIZE, dataType = "Long", paramType = "query"),
+            @ApiImplicitParam(name = "sort", value = "the properties to sort by (optional, date | basePrice | title, default = " +
+                    DEFAULT_SORT_FIELD + ")",
+                    allowableValues = "date, basePrice, title", defaultValue = DEFAULT_SORT_FIELD,
+                    dataType = "String", paramType = "query"),
+            @ApiImplicitParam(name = "order", value = "sorting order (optional, ASC | DESC, default = " +
+                    DEFAULT_SORT_DIRECTION + ")",
+                    allowableValues = "ASC, DESC", defaultValue = DEFAULT_SORT_DIRECTION,
+                    dataType = "String", paramType = "query"),
+            @ApiImplicitParam(name = "title", value = "filter query for offers titles (optional, at least two characters)",
                     dataType = "String", paramType = "query"),
             @ApiImplicitParam(name = "priceMin", value = "minimum price (optional)",
                     dataType = "Float", paramType = "query"),
@@ -65,51 +93,77 @@ public class OfferController {
             @ApiImplicitParam(name = "dateMax", value = "offer not newer than (optional)",
                     dataType = "Long", paramType = "query")
     })
-    @ApiOperation(value = "Returns all existing offers (with optional filter criteria)")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully retrieved offer(s)"),
+    })
+    @ApiOperation(value = "Returns all existing offers (with optional paging, filter criteria and sort strategy)")
+    @ResponseStatus(value = HttpStatus.OK)
     @GetMapping
-    public List<Offer> searchOffers(@RequestParam(required = false) Optional<String> title,
-                                    @RequestParam(required = false) Optional<Float> priceMin,
-                                    @RequestParam(required = false) Optional<Float> priceMax,
-                                    @RequestParam(required = false) Optional<Long> dateMin,
-                                    @RequestParam(required = false) Optional<Long> dateMax) {
+    public Page<Offer> searchOffers(@RequestParam(name = "page", required = false) Optional<Integer> page,
+                                    @RequestParam(name = "pageSize", required = false) Optional<Integer> pageSize,
+                                    @RequestParam(name = "sort", required = false) Optional<String> sort,
+                                    @RequestParam(name = "order", required = false) Optional<String> order,
+                                    @RequestParam(name = "title", required = false) Optional<String> title,
+                                    @RequestParam(name = "priceMin", required = false) Optional<Float> priceMin,
+                                    @RequestParam(name = "priceMax", required = false) Optional<Float> priceMax,
+                                    @RequestParam(name = "dateMin", required = false) Optional<Long> dateMin,
+                                    @RequestParam(name = "dateMax", required = false) Optional<Long> dateMax) {
+
+        final int pageNumber;
+        if (page.isPresent()) {
+            pageNumber = page.get() < FIRST_PAGE ? Integer.valueOf(DEFAULT_PAGE) : page.get();
+        } else {
+            pageNumber = Integer.valueOf(DEFAULT_PAGE);
+        }
+
+        final int pageSizeNumber;
+        if (pageSize.isPresent()) {
+            pageSizeNumber = pageSize.get() < PAGE_SIZE_MAX ? pageSize.get() : PAGE_SIZE_MAX;
+        } else {
+            pageSizeNumber = Integer.valueOf(DEFAULT_PAGE_SIZE);
+        }
+
+        final String sortField = sort.orElse(DEFAULT_SORT_FIELD);
+        final String sortOrder = order.orElse(DEFAULT_SORT_DIRECTION);
+
+        Pageable pageable = PageRequest.of(pageNumber - FIRST_PAGE, pageSizeNumber,
+                Direction.fromString(sortOrder), sortField);
+
         final OfferSpecificationsBuilder builder = new OfferSpecificationsBuilder();
-        if (title.isPresent()) {
+        if (title.isPresent() && (title.get().length() > 1) && !title.get().matches("^[0-9]{2,}$")) {
             String[] titleKeywords = title.get()
                     .substring(0, title.get().length() > OFFER_TITLE_MAX_LENGTH ?
                             OFFER_TITLE_MAX_LENGTH : title.get().length())
-                    .replaceAll("[^a-zA-Z0-9ąĄćĆęĘłŁńŃóÓśŚżŻźŹ ]", "")
+                    .replaceAll("[^" + ACCEPTABLE_TITLE_SEARCH_CHARS + "]", "")
                     .toLowerCase().split(" ");
             for (String titleKeyword : titleKeywords) {
-                boolean compliant = !titleKeyword.matches("^.$") &&
-                        !titleKeyword.matches("^[0-9]{2,}$");
-                if (compliant) {
-                    builder.with("title", ":", titleKeyword);
-                }
+                builder.with("title", ":", titleKeyword);
             }
         }
+        final Specification<Offer> filter = builder.build();
+
         dateMin.ifPresent(aLong -> builder.with("date", "≥", aLong));
         dateMax.ifPresent(aLong -> builder.with("date", "≤", aLong));
         priceMin.ifPresent(aFloat -> builder.with("basePrice", "≥", aFloat));
         priceMax.ifPresent(aFloat -> builder.with("basePrice", "≤", aFloat));
 
-        Specification<Offer> filter = builder.build();
-        return service.getAll(filter);
+        return service.getAll(pageable, filter);
     }
 
     @ApiOperation(value = "Returns offer by id")
-    @GetMapping(value = "/{id}")
-    public Offer get(@PathVariable UUID id) {
+    @GetMapping(value = "{id}")
+    public Optional<Offer> get(@PathVariable UUID id) {
         return service.get(id);
     }
 
     @ApiOperation(value = "Updates offer by id")
-    @PutMapping(value = "/{id}")
+    @PutMapping(value = "{id}")
     public void update(Offer offer) {
         service.update(offer);
     }
 
     @ApiOperation(value = "Removes offer by id")
-    @DeleteMapping(value = "/{id}")
+    @DeleteMapping(value = "{id}")
     public void delete(@PathVariable UUID id) {
         service.delete(id);
     }

--- a/backend/src/main/java/com/intive/shopme/controller/OfferController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/OfferController.java
@@ -69,11 +69,12 @@ public class OfferController {
 
     @ApiImplicitParams({
             @ApiImplicitParam(name = "page", value = "requested page number (optional, counting from " + FIRST_PAGE +
-                    ", default = " + DEFAULT_PAGE + ")",
-                    defaultValue = DEFAULT_PAGE, dataType = "Long", paramType = "query"),
+                    ", default = " + DEFAULT_PAGE + ")", defaultValue = DEFAULT_PAGE,
+                    dataType = "Long", paramType = "query"),
             @ApiImplicitParam(name = "pageSize", value = "number of offers per page (optional, default = " +
-                    DEFAULT_PAGE_SIZE + ", max " + PAGE_SIZE_MAX + ")", allowableValues = "range[1, 5]",
-                    defaultValue = DEFAULT_PAGE_SIZE, dataType = "Long", paramType = "query"),
+                    DEFAULT_PAGE_SIZE + ", max " + PAGE_SIZE_MAX + ")",
+                    allowableValues = "range[1, " + PAGE_SIZE_MAX + "]", defaultValue = DEFAULT_PAGE_SIZE,
+                    dataType = "Long", paramType = "query"),
             @ApiImplicitParam(name = "sort", value = "the properties to sort by (optional, date | basePrice | title, default = " +
                     DEFAULT_SORT_FIELD + ")",
                     allowableValues = "date, basePrice, title", defaultValue = DEFAULT_SORT_FIELD,
@@ -126,7 +127,7 @@ public class OfferController {
         final String sortField = sort.orElse(DEFAULT_SORT_FIELD);
         final String sortOrder = order.orElse(DEFAULT_SORT_DIRECTION);
 
-        Pageable pageable = PageRequest.of(pageNumber - FIRST_PAGE, pageSizeNumber,
+        final Pageable pageable = PageRequest.of(pageNumber - FIRST_PAGE, pageSizeNumber,
                 Direction.fromString(sortOrder), sortField);
 
         final OfferSpecificationsBuilder builder = new OfferSpecificationsBuilder();
@@ -152,7 +153,7 @@ public class OfferController {
 
     @ApiOperation(value = "Returns offer by id")
     @GetMapping(value = "{id}")
-    public Optional<Offer> get(@PathVariable UUID id) {
+    public Offer get(@PathVariable UUID id) {
         return service.get(id);
     }
 

--- a/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecification.java
+++ b/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecification.java
@@ -23,11 +23,11 @@ class OfferSpecification implements Specification<Offer> {
                 result = builder.greaterThanOrEqualTo(root.get(criteria.getKey()), criteria.getValue().toString());
                 break;
             case "≤":
-                result = builder.lessThanOrEqualTo(root.<String>get(criteria.getKey()), criteria.getValue().toString());
+                result = builder.lessThanOrEqualTo(root.get(criteria.getKey()), criteria.getValue().toString());
                 break;
             case ":":
                 if (root.get(criteria.getKey()).getJavaType() == String.class) {
-                    result = builder.like(builder.lower(root.<String>get(criteria.getKey())),
+                    result = builder.like(builder.lower(root.get(criteria.getKey())),
                             "%" + criteria.getValue() + "%");
                 } else {
                     result = builder.equal(root.get(criteria.getKey()), criteria.getValue());

--- a/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecification.java
+++ b/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecification.java
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 @AllArgsConstructor
-public class OfferSpecification implements Specification<Offer> {
+class OfferSpecification implements Specification<Offer> {
 
     private final SearchCriteria criteria;
 
@@ -20,7 +20,7 @@ public class OfferSpecification implements Specification<Offer> {
         Predicate result = null;
         switch (criteria.getOperation()) {
             case "≥":
-                result = builder.greaterThanOrEqualTo(root.<String>get(criteria.getKey()), criteria.getValue().toString());
+                result = builder.greaterThanOrEqualTo(root.get(criteria.getKey()), criteria.getValue().toString());
                 break;
             case "≤":
                 result = builder.lessThanOrEqualTo(root.<String>get(criteria.getKey()), criteria.getValue().toString());
@@ -37,4 +37,5 @@ public class OfferSpecification implements Specification<Offer> {
 
         return result;
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecificationsBuilder.java
+++ b/backend/src/main/java/com/intive/shopme/controller/filter/OfferSpecificationsBuilder.java
@@ -32,4 +32,5 @@ public class OfferSpecificationsBuilder {
 
         return result;
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/controller/filter/SearchCriteria.java
+++ b/backend/src/main/java/com/intive/shopme/controller/filter/SearchCriteria.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 
 @Data
 @AllArgsConstructor
-public class SearchCriteria {
+class SearchCriteria {
+
     private final String key;
     private final String operation;
     private final Object value;
+
 }

--- a/backend/src/main/java/com/intive/shopme/model/Category.java
+++ b/backend/src/main/java/com/intive/shopme/model/Category.java
@@ -14,4 +14,5 @@ public class Category extends Identifiable {
 
     @ApiModelProperty(value = "Represents category's name", required = true, position = 2, example = "inne")
     private String name;
+
 }

--- a/backend/src/main/java/com/intive/shopme/model/Offer.java
+++ b/backend/src/main/java/com/intive/shopme/model/Offer.java
@@ -21,6 +21,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import java.time.Instant;
 
 import static com.intive.shopme.config.AppConfig.OFFER_DESCRIPTION_MAX_LENGTH;
 import static com.intive.shopme.config.AppConfig.OFFER_TITLE_MAX_LENGTH;
@@ -33,9 +34,9 @@ import static com.intive.shopme.config.AppConfig.OFFER_TITLE_MAX_LENGTH;
 @NoArgsConstructor
 public class Offer extends Identifiable {
 
-    @ApiModelProperty(value = "Represents offer's date of submitting", position = 2,
-            example = "1234567890")
-    private final Long date = System.currentTimeMillis();
+    @ApiModelProperty(value = "Represents offer's date of submitting (EPOCH time in milliseconds)", position = 2,
+            example = "1520031600000")
+    private Long date = Instant.now().toEpochMilli();
 
     @ApiModelProperty(value = "Represents offer's title", required = true, position = 3,
             example = "Odśnieżanie Niebuszewo")

--- a/backend/src/main/java/com/intive/shopme/repository/OfferRepository.java
+++ b/backend/src/main/java/com/intive/shopme/repository/OfferRepository.java
@@ -1,13 +1,17 @@
 package com.intive.shopme.repository;
 
 import com.intive.shopme.model.Offer;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface OfferRepository extends JpaRepository<Offer, UUID>, JpaSpecificationExecutor<Offer> {
+public interface OfferRepository extends PagingAndSortingRepository<Offer, UUID> {
+
+    Page<Offer> findAll(Specification<Offer> filter, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -29,4 +29,5 @@ public class CategoryService {
     public Category getCategoryById(UUID id) {
         return repository.getOne(id);
     }
+
 }

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -14,7 +14,6 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,8 +34,8 @@ public class OfferService {
         return repository.findAll(filter, pageable);
     }
 
-    public Optional<Offer> get(UUID id) {
-        return repository.findById(id);
+    public Offer get(UUID id) {
+        return repository.findById(id).orElse(null);
     }
 
     public void add(Offer offer) {

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -3,6 +3,8 @@ package com.intive.shopme.service;
 import com.intive.shopme.model.Offer;
 import com.intive.shopme.repository.OfferRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
@@ -12,11 +14,9 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import java.util.Comparator;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -31,14 +31,12 @@ public class OfferService {
         this.repository = repository;
     }
 
-    public List<Offer> getAll(Specification<Offer> filter) {
-        return repository.findAll(filter).stream()
-                .sorted(Comparator.comparing(Offer::getDate).reversed())
-                .collect(Collectors.toList());
+    public Page<Offer> getAll(Pageable pageable, Specification<Offer> filter) {
+        return repository.findAll(filter, pageable);
     }
 
-    public Offer get(UUID id) {
-        return repository.getOne(id);
+    public Optional<Offer> get(UUID id) {
+        return repository.findById(id);
     }
 
     public void add(Offer offer) {
@@ -61,4 +59,5 @@ public class OfferService {
             throw new ConstraintViolationException(violations);
         }
     }
+
 }


### PR DESCRIPTION
1. Wdrożona obsługa stronicowania przy wyszukiwaniu ofert.
2. Ustawiłem limit na max wielkość strony na 100 ofert (aby nie dać zarżnąć serwera).
3. Przy okazji przeniosłem funkcjonalność sortowania do PagingAndSortingRepository zamiast dotychczasowego Java stream. 
4. Udostępniłem parametry sortowania przez REST API (aby się uniezależnić od zmian oczekiwań w tym zakresie).
5. Doprecyzowałem opis kilku parametrów zapytań w Swagger specs.
6. Drobne zmiany modyfikatorów dostępu dla kilku klas (package).
7. Zmiana przykładowej EPOCH daty w Swagger specs (z jakiejś 1970... na 2018-03-03 czyli start programu).