### PR TITLE
hide /actuator endpoints in Swagger specification

### DIFF
--- a/backend/src/main/java/com/intive/shopme/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/intive/shopme/config/SwaggerConfig.java
@@ -41,7 +41,7 @@ public class SwaggerConfig {
                 new Docket(DocumentationType.SWAGGER_2)
                         .select()
                         .apis(RequestHandlerSelectors.any())
-                        .paths(Predicates.not(PathSelectors.regex("/error")))
+                        .paths(Predicates.not(PathSelectors.regex("/error|/actuator.*")))
                         .build()
                         .apiInfo(createApiInfo()));
     }


### PR DESCRIPTION
Schowanie endpointów od Spring Boot actuatora w specyfikacji Swagger