### PR TITLE
Get rid of warning "spring.jpa.open-in-view is enabled by default..."

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.sqlScriptEncoding=UTF-8
 # swagger default API URL configuration
 server.external.host=localhost:8080
 server.external.url.context=/
+
+# To get rid of warning "spring.jpa.open-in-view is enabled by default..." at app start
+spring.jpa.open-in-view=false


### PR DESCRIPTION
Pozbycie się WARNINGa przy starcie aplikacji:

2018-04-03 20:57:49.261  WARN 9456 --- [  restartedMain] aWebConfiguration$JpaWebMvcConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning