### PR TITLE
Remove null and empty fields from REST API responses

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,3 +10,6 @@ server.external.url.context=/
 
 # To get rid of warning "spring.jpa.open-in-view is enabled by default..." at app start
 spring.jpa.open-in-view=false
+
+# Remove null and empty value fields from REST API response
+spring.jackson.default-property-inclusion=NON_EMPTY


### PR DESCRIPTION
Pierwsza propozycja implementacji wyłączenia wysyłania pól o wartościach null i pustych (na sztywno ustawione w application.properties, bez dynamicznego kodu i flagi w klasie konfiguracyjnej)