### PR TITLE
PRODPFIP-80 - obsługa błędów klienckich

### DIFF
--- a/backend/src/main/java/com/intive/shopme/config/AppConfig.java
+++ b/backend/src/main/java/com/intive/shopme/config/AppConfig.java
@@ -19,6 +19,9 @@ public final class AppConfig {
     public static final String DEFAULT_SORT_FIELD = "date";
     public static final String DEFAULT_SORT_DIRECTION = "DESC";
 
+    public static final String OFFER_NOT_FOUND = "Offer not found";
+    public static final String CATEGORY_NOT_FOUND = "Category not found";
+
     private AppConfig() {
     }
 

--- a/backend/src/main/java/com/intive/shopme/config/AppConfig.java
+++ b/backend/src/main/java/com/intive/shopme/config/AppConfig.java
@@ -20,6 +20,7 @@ public final class AppConfig {
     public static final String DEFAULT_SORT_DIRECTION = "DESC";
 
     public static final String OFFER_NOT_FOUND = "Offer not found";
+    public static final String OFFER_SWAGGER_NOT_FOUND = "Offer with this ID has not found";
     public static final String CATEGORY_NOT_FOUND = "Category not found";
 
     private AppConfig() {

--- a/backend/src/main/java/com/intive/shopme/controller/CategoryController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/CategoryController.java
@@ -4,6 +4,8 @@ import com.intive.shopme.model.Category;
 import com.intive.shopme.service.CategoryService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,6 +35,10 @@ public class CategoryController {
         return service.getAll();
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Category with this ID has not found"),
+            @ApiResponse(code = 409, message = "Category already exist")
+    })
     @PostMapping
     @ApiOperation(value = "Saves new category")
     public void add(@RequestBody Category category) {

--- a/backend/src/main/java/com/intive/shopme/controller/OfferController.java
+++ b/backend/src/main/java/com/intive/shopme/controller/OfferController.java
@@ -33,14 +33,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static com.intive.shopme.config.ApiUrl.OFFERS;
-import static com.intive.shopme.config.AppConfig.ACCEPTABLE_TITLE_SEARCH_CHARS;
-import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE;
-import static com.intive.shopme.config.AppConfig.DEFAULT_PAGE_SIZE;
-import static com.intive.shopme.config.AppConfig.DEFAULT_SORT_DIRECTION;
-import static com.intive.shopme.config.AppConfig.DEFAULT_SORT_FIELD;
-import static com.intive.shopme.config.AppConfig.FIRST_PAGE;
-import static com.intive.shopme.config.AppConfig.OFFER_TITLE_MAX_LENGTH;
-import static com.intive.shopme.config.AppConfig.PAGE_SIZE_MAX;
+import static com.intive.shopme.config.AppConfig.*;
 
 @Validated
 @RestController
@@ -58,6 +51,7 @@ public class OfferController {
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "New offer successfully created"),
             @ApiResponse(code = 422, message = "New offer data validation error")
+
     })
     @ApiOperation(value = "Saves new offer")
     @PostMapping
@@ -151,18 +145,27 @@ public class OfferController {
         return service.getAll(pageable, filter);
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = OFFER_SWAGGER_NOT_FOUND)
+    })
     @ApiOperation(value = "Returns offer by id")
     @GetMapping(value = "{id}")
     public Offer get(@PathVariable UUID id) {
         return service.get(id);
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = OFFER_SWAGGER_NOT_FOUND)
+    })
     @ApiOperation(value = "Updates offer by id")
     @PutMapping(value = "{id}")
     public void update(Offer offer) {
         service.update(offer);
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = OFFER_SWAGGER_NOT_FOUND)
+    })
     @ApiOperation(value = "Removes offer by id")
     @DeleteMapping(value = "{id}")
     public void delete(@PathVariable UUID id) {

--- a/backend/src/main/java/com/intive/shopme/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/intive/shopme/repository/CategoryRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
 
     boolean existsByName(String name);
+
+    boolean existsByTranslateKey(String translateKey);
 }

--- a/backend/src/main/java/com/intive/shopme/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/intive/shopme/repository/CategoryRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -2,8 +2,8 @@ package com.intive.shopme.service;
 
 import com.intive.shopme.model.Category;
 import com.intive.shopme.repository.CategoryRepository;
+import com.intive.shopme.util.validation.error.AlreadyExistException;
 import com.intive.shopme.util.validation.error.NotFoundException;
-import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,11 +25,16 @@ public class CategoryService {
     }
 
     public void add(Category category) {
+        if (repository.existsByName(category.getName())) {
+            throw new AlreadyExistException("Category with this name exist");
+        }
         repository.save(category);
     }
 
     public Category getCategoryById(UUID id) {
-        if(!repository.existsById(id)) throw new NotFoundException("Category");
+        if (!repository.existsById(id)) {
+            throw new NotFoundException("Category not found");
+        }
         return repository.getOne(id);
     }
 

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -26,7 +26,10 @@ public class CategoryService {
 
     public void add(Category category) {
         if (repository.existsByName(category.getName())) {
-            throw new AlreadyExistException("Category with this name exist");
+            throw new AlreadyExistException("Category with this name already exist");
+        }
+        if(repository.existsByTranslateKey(category.getTranslateKey())){
+            throw new AlreadyExistException("Category with this translateKey already exist");
         }
         repository.save(category);
     }

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -2,8 +2,8 @@ package com.intive.shopme.service;
 
 import com.intive.shopme.model.Category;
 import com.intive.shopme.repository.CategoryRepository;
+import com.intive.shopme.util.RepositoryVerifier;
 import com.intive.shopme.util.validation.error.AlreadyExistException;
-import com.intive.shopme.util.validation.error.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,10 +37,7 @@ public class CategoryService {
     }
 
     public Category getCategoryById(UUID id) {
-        if (!repository.existsById(id)) {
-            throw new NotFoundException(CATEGORY_NOT_FOUND);
-        }
+        RepositoryVerifier.throwNotFoundExceptionIfEntityNotFound(id, repository, CATEGORY_NOT_FOUND);
         return repository.getOne(id);
     }
-
 }

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.UUID;
 
+import static com.intive.shopme.config.AppConfig.CATEGORY_NOT_FOUND;
+
 @Service
 public class CategoryService {
 
@@ -28,7 +30,7 @@ public class CategoryService {
         if (repository.existsByName(category.getName())) {
             throw new AlreadyExistException("Category with this name already exist");
         }
-        if(repository.existsByTranslateKey(category.getTranslateKey())){
+        if (repository.existsByTranslateKey(category.getTranslateKey())) {
             throw new AlreadyExistException("Category with this translateKey already exist");
         }
         repository.save(category);
@@ -36,7 +38,7 @@ public class CategoryService {
 
     public Category getCategoryById(UUID id) {
         if (!repository.existsById(id)) {
-            throw new NotFoundException("Category not found");
+            throw new NotFoundException(CATEGORY_NOT_FOUND);
         }
         return repository.getOne(id);
     }

--- a/backend/src/main/java/com/intive/shopme/service/CategoryService.java
+++ b/backend/src/main/java/com/intive/shopme/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.intive.shopme.service;
 
 import com.intive.shopme.model.Category;
 import com.intive.shopme.repository.CategoryRepository;
+import com.intive.shopme.util.validation.error.NotFoundException;
+import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +29,7 @@ public class CategoryService {
     }
 
     public Category getCategoryById(UUID id) {
+        if(!repository.existsById(id)) throw new NotFoundException("Category");
         return repository.getOne(id);
     }
 

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -18,6 +18,8 @@ import javax.validation.ValidatorFactory;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.intive.shopme.config.AppConfig.OFFER_NOT_FOUND;
+
 @Service
 @Transactional
 public class OfferService {
@@ -36,7 +38,7 @@ public class OfferService {
     }
 
     public Offer get(UUID id) {
-        return repository.findById(id).orElseThrow(()->new NotFoundException("Offer not found"));
+        return repository.findById(id).orElseThrow(() -> new NotFoundException(OFFER_NOT_FOUND));
     }
 
     public void add(Offer offer) {
@@ -46,14 +48,14 @@ public class OfferService {
 
     public void update(Offer offer) {
         if (!repository.existsById(offer.getId())) {
-            throw new NotFoundException("Offer not found");
+            throw new NotFoundException(OFFER_NOT_FOUND);
         }
         repository.save(offer);
     }
 
     public void delete(UUID id) {
         if (!repository.existsById(id)) {
-            throw new NotFoundException("Offer not found");
+            throw new NotFoundException(OFFER_NOT_FOUND);
         }
         repository.deleteById(id);
     }

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -2,6 +2,7 @@ package com.intive.shopme.service;
 
 import com.intive.shopme.model.Offer;
 import com.intive.shopme.repository.OfferRepository;
+import com.intive.shopme.util.RepositoryVerifier;
 import com.intive.shopme.util.validation.error.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -47,16 +48,12 @@ public class OfferService {
     }
 
     public void update(Offer offer) {
-        if (!repository.existsById(offer.getId())) {
-            throw new NotFoundException(OFFER_NOT_FOUND);
-        }
+        RepositoryVerifier.throwNotFoundExceptionIfEntityNotFound(offer.getId(), repository, OFFER_NOT_FOUND);
         repository.save(offer);
     }
 
     public void delete(UUID id) {
-        if (!repository.existsById(id)) {
-            throw new NotFoundException(OFFER_NOT_FOUND);
-        }
+        RepositoryVerifier.throwNotFoundExceptionIfEntityNotFound(id, repository, OFFER_NOT_FOUND);
         repository.deleteById(id);
     }
 
@@ -67,5 +64,4 @@ public class OfferService {
             throw new ConstraintViolationException(violations);
         }
     }
-
 }

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -2,6 +2,7 @@ package com.intive.shopme.service;
 
 import com.intive.shopme.model.Offer;
 import com.intive.shopme.repository.OfferRepository;
+import com.intive.shopme.util.validation.error.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,7 +36,7 @@ public class OfferService {
     }
 
     public Offer get(UUID id) {
-        return repository.findById(id).orElse(null);
+        return repository.findById(id).orElseThrow(()->new NotFoundException("Offer not found"));
     }
 
     public void add(Offer offer) {
@@ -44,10 +45,12 @@ public class OfferService {
     }
 
     public void update(Offer offer) {
+        if(!repository.existsById(offer.getId())) throw new NotFoundException("Offer");
         repository.save(offer);
     }
 
     public void delete(UUID id) {
+        if(!repository.existsById(id)) throw new NotFoundException("Offer");
         repository.deleteById(id);
     }
 

--- a/backend/src/main/java/com/intive/shopme/service/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/service/OfferService.java
@@ -45,12 +45,16 @@ public class OfferService {
     }
 
     public void update(Offer offer) {
-        if(!repository.existsById(offer.getId())) throw new NotFoundException("Offer");
+        if (!repository.existsById(offer.getId())) {
+            throw new NotFoundException("Offer not found");
+        }
         repository.save(offer);
     }
 
     public void delete(UUID id) {
-        if(!repository.existsById(id)) throw new NotFoundException("Offer");
+        if (!repository.existsById(id)) {
+            throw new NotFoundException("Offer not found");
+        }
         repository.deleteById(id);
     }
 

--- a/backend/src/main/java/com/intive/shopme/util/RepositoryVerifier.java
+++ b/backend/src/main/java/com/intive/shopme/util/RepositoryVerifier.java
@@ -1,0 +1,22 @@
+package com.intive.shopme.util;
+
+import com.intive.shopme.repository.CategoryRepository;
+import com.intive.shopme.repository.OfferRepository;
+import com.intive.shopme.util.validation.error.NotFoundException;
+
+import java.util.UUID;
+
+public final class RepositoryVerifier {
+
+    public static void throwNotFoundExceptionIfEntityNotFound(UUID id, CategoryRepository repository, String message) {
+        if (!repository.existsById(id)) {
+            throw new NotFoundException(message);
+        }
+    }
+
+    public static void throwNotFoundExceptionIfEntityNotFound(UUID id, OfferRepository repository, String message) {
+        if (!repository.existsById(id)) {
+            throw new NotFoundException(message);
+        }
+    }
+}

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/AlreadyExistException.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/AlreadyExistException.java
@@ -1,9 +1,7 @@
 package com.intive.shopme.util.validation.error;
 
 import lombok.Data;
-import lombok.Getter;
 
-@Getter
 @Data
 public class AlreadyExistException extends RuntimeException {
 

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/AlreadyExistException.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/AlreadyExistException.java
@@ -1,0 +1,11 @@
+package com.intive.shopme.util.validation.error;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Data
+public class AlreadyExistException extends RuntimeException {
+
+    private final String name;
+}

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
@@ -1,6 +1,5 @@
 package com.intive.shopme.util.validation.error;
 
-import org.aspectj.weaver.ast.Not;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -43,5 +42,4 @@ public class ErrorHandlingController {
     public ErrorResponse handleAlreadyExistException(AlreadyExistException ex) {
         return new ErrorResponse(HttpStatus.CONFLICT, ex.getName());
     }
-
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
@@ -15,10 +15,10 @@ import java.util.Set;
 public class ErrorHandlingController {
 
     @ExceptionHandler(value = {ConstraintViolationException.class})
-    public ResponseEntity<ExceptionResponse> handleInvalidInput(ConstraintViolationException ex) {
+    public ResponseEntity<ValidationExceptionResponse> handleInvalidInput(ConstraintViolationException ex) {
 
         Set violations = ex.getConstraintViolations();
-        ExceptionResponse eR = new ExceptionResponse();
+        ValidationExceptionResponse eR = new ValidationExceptionResponse();
         eR.setCode(HttpStatus.UNPROCESSABLE_ENTITY.value());
 
         for (int i = 0; i < violations.size(); i++) {

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
@@ -15,31 +15,31 @@ import java.util.Set;
 public class ErrorHandlingController {
 
     @ExceptionHandler(value = {ConstraintViolationException.class})
-    public ResponseEntity<ValidationExceptionResponse> handleInvalidInput(ConstraintViolationException ex) {
+    public ResponseEntity<ValidationExceptionResponse> handleInvalidInput(ConstraintViolationException exception) {
 
-        Set violations = ex.getConstraintViolations();
-        ValidationExceptionResponse eR = new ValidationExceptionResponse();
-        eR.setCode(HttpStatus.UNPROCESSABLE_ENTITY.value());
+        Set violations = exception.getConstraintViolations();
+        ValidationExceptionResponse exceptionResponse = new ValidationExceptionResponse();
+        exceptionResponse.setCode(HttpStatus.UNPROCESSABLE_ENTITY.value());
 
         for (int i = 0; i < violations.size(); i++) {
-            ConstraintViolation v = (ConstraintViolation) violations.toArray()[i];
-            eR.add(v.getPropertyPath().toString(), v.getMessage());
+            ConstraintViolation violation = (ConstraintViolation) violations.toArray()[i];
+            exceptionResponse.add(violation.getPropertyPath().toString(), violation.getMessage());
         }
 
-        return new ResponseEntity<>(eR, HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @ExceptionHandler(value = {NotFoundException.class})
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
     @ResponseBody
-    public ErrorResponse handleNotFoundException(NotFoundException ex) {
-        return new ErrorResponse(HttpStatus.NOT_FOUND, ex.getName());
+    public ErrorResponse handleNotFoundException(NotFoundException exception) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND, exception.getName());
     }
 
     @ExceptionHandler(value = {AlreadyExistException.class})
     @ResponseStatus(value = HttpStatus.CONFLICT)
     @ResponseBody
-    public ErrorResponse handleAlreadyExistException(AlreadyExistException ex) {
-        return new ErrorResponse(HttpStatus.CONFLICT, ex.getName());
+    public ErrorResponse handleAlreadyExistException(AlreadyExistException exception) {
+        return new ErrorResponse(HttpStatus.CONFLICT, exception.getName());
     }
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -29,11 +30,18 @@ public class ErrorHandlingController {
         return new ResponseEntity<>(eR, HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
-    @ExceptionHandler(value={NotFoundException.class})
+    @ExceptionHandler(value = {NotFoundException.class})
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
     @ResponseBody
-    public ErrorResponse handleNotFoundException(NotFoundException ex){
-        return new ErrorResponse(HttpStatus.NOT_FOUND,ex.getName());
+    public ErrorResponse handleNotFoundException(NotFoundException ex) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND, ex.getName());
     }
 
+    @ExceptionHandler(value = {AlreadyExistException.class})
+    @ResponseStatus(value = HttpStatus.CONFLICT)
+    @ResponseBody
+    public ErrorResponse handleAlreadyExistException(AlreadyExistException ex) {
+        return new ErrorResponse(HttpStatus.CONFLICT, ex.getName());
+    }
 
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorHandlingController.java
@@ -1,9 +1,11 @@
 package com.intive.shopme.util.validation.error;
 
+import org.aspectj.weaver.ast.Not;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -26,4 +28,12 @@ public class ErrorHandlingController {
 
         return new ResponseEntity<>(eR, HttpStatus.UNPROCESSABLE_ENTITY);
     }
+
+    @ExceptionHandler(value={NotFoundException.class})
+    @ResponseBody
+    public ErrorResponse handleNotFoundException(NotFoundException ex){
+        return new ErrorResponse(HttpStatus.NOT_FOUND,ex.getName());
+    }
+
+
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorResponse.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorResponse.java
@@ -1,14 +1,11 @@
 package com.intive.shopme.util.validation.error;
 
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@Setter
 @Data
-public class ErrorResponse  {
+public class ErrorResponse {
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorResponse.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.intive.shopme.util.validation.error;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Data
+public class ErrorResponse  {
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/NotFoundException.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.intive.shopme.util.validation.error;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Data
+public class NotFoundException extends RuntimeException {
+    private final String name;
+
+}

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/NotFoundException.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/NotFoundException.java
@@ -1,11 +1,9 @@
 package com.intive.shopme.util.validation.error;
 
 import lombok.Data;
-import lombok.Getter;
 
-@Getter
 @Data
 public class NotFoundException extends RuntimeException {
-    private final String name;
 
+    private final String name;
 }

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ValidationExceptionResponse.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ValidationExceptionResponse.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 import java.util.HashMap;
 
 @Setter
-public class ExceptionResponse {
+public class ValidationExceptionResponse {
 
     private int code;
     private HashMap<String, String> errors = new HashMap<>();

--- a/backend/src/main/java/com/intive/shopme/util/validation/error/ValidationExceptionResponse.java
+++ b/backend/src/main/java/com/intive/shopme/util/validation/error/ValidationExceptionResponse.java
@@ -1,14 +1,14 @@
 package com.intive.shopme.util.validation.error;
 
-import lombok.Setter;
+import lombok.Data;
 
 import java.util.HashMap;
 
-@Setter
+@Data
 public class ValidationExceptionResponse {
 
-    private int code;
-    private HashMap<String, String> errors = new HashMap<>();
+    private Integer code;
+    private final HashMap<String, String> errors = new HashMap<>();
 
     public void add(String field, String msg) {
         errors.put(field, msg);


### PR DESCRIPTION
Zawiera obsługę błędów:
/offers/id: gdy nie ma podanego id w bazie dla **PUT,DELETE,GET**
/categories : **POST**: gdy istnieje już dany _name_ lub _translateKey_ w bazie i nie możemy utworzyć kolejnej kategorii
+ **GET** z /categories/id (tutaj nie było obsługi w kontrolerze, ale jest funkcja w service)