### PR TITLE
extend search offer by filtering results by user, voivodeship and city

### DIFF
--- a/backend/src/main/java/com/intive/shopme/config/SwaggerApiInfoConfigurer.java
+++ b/backend/src/main/java/com/intive/shopme/config/SwaggerApiInfoConfigurer.java
@@ -7,7 +7,7 @@ public final class SwaggerApiInfoConfigurer {
 
     private static final String TITLE = "ShopMe by Intive Patronage `18 team";
     private static final String DESC = "ShopMe is a Web Application created during Intive Patronage `18 Project";
-    private static final String VERSION = "1.5";
+    private static final String VERSION = "1.6";
 
     private SwaggerApiInfoConfigurer() {
     }

--- a/backend/src/main/java/com/intive/shopme/offer/OfferService.java
+++ b/backend/src/main/java/com/intive/shopme/offer/OfferService.java
@@ -3,6 +3,8 @@ package com.intive.shopme.offer;
 import com.intive.shopme.model.db.DbOffer;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -18,8 +20,8 @@ class OfferService {
         this.repository = repository;
     }
 
-    Page<DbOffer> getAll(OfferSearchParams offerSearchParams) {
-        return repository.findAll(offerSearchParams.filter(), offerSearchParams.pageable());
+    Page<DbOffer> getAll(Specification<DbOffer> specification, Pageable pageable) {
+        return repository.findAll(specification, pageable);
     }
 
     DbOffer get(UUID id) {

--- a/backend/src/main/java/com/intive/shopme/offer/OfferSpecification.java
+++ b/backend/src/main/java/com/intive/shopme/offer/OfferSpecification.java
@@ -1,6 +1,7 @@
 package com.intive.shopme.offer;
 
 import com.intive.shopme.model.db.DbOffer;
+import com.intive.shopme.model.db.DbUser;
 import lombok.AllArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -36,6 +37,11 @@ class OfferSpecification implements Specification<DbOffer> {
                         result = builder.lessThanOrEqualTo(datePath, dateValue);
                         break;
                 }
+                break;
+            case "user":
+                Path userPath = root.get(key);
+                DbUser userValue = (DbUser) criteria.getValue();
+                result = builder.equal(userPath, userValue);
                 break;
             case "empty":
                 result = builder.and().not();

--- a/backend/src/main/java/com/intive/shopme/registration/UserRepository.java
+++ b/backend/src/main/java/com/intive/shopme/registration/UserRepository.java
@@ -11,5 +11,7 @@ interface UserRepository extends JpaRepository<DbUser, UUID> {
 
     boolean existsByEmail(String email);
 
+    boolean existsById(UUID id);
+
     DbUser findOneByEmail(String email);
 }

--- a/backend/src/main/java/com/intive/shopme/registration/UserService.java
+++ b/backend/src/main/java/com/intive/shopme/registration/UserService.java
@@ -34,6 +34,10 @@ public class UserService {
         return repository.existsByEmail(email.toLowerCase());
     }
 
+    public boolean existsById(UUID id) {
+        return repository.existsById(id);
+    }
+
     public DbUser findOneByEmail(String email) {
         return repository.findOneByEmail(email);
     }


### PR DESCRIPTION
rozszerzenie wyszukiwarki ofert o filtrowanie po userze, mieście i województwie

wychodząc naprzeciwko postulatowi frontendu z ostatniego spotkania (aby dać znać jeśli jest coś co jeszcze można łatwo/szybko wdrożyć, co jest gotowego) chciałbym zgłosić im parę pomysłów w tym zakresie bazujących na tym rozszerzonym wyszukiwaniu oraz ich gotowej stronie wyświetlana ofert z danej kategorii